### PR TITLE
Restore intentionally mistyped `mkdirr` example in README files

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -198,7 +198,7 @@ ais --version
 ais ask "Hello, AIS!"
 
 # Test automatic error analysis (enter a command with an intentional typo)
-mkdir /tmp/test
+mkdirr /tmp/test
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ ais --version
 ais ask "你好，AIS！"
 
 # 测试自动错误分析（故意输错命令）
-mkdir /tmp/test
+mkdirr /tmp/test
 ```
 
 ---


### PR DESCRIPTION
Context
- The "Test automatic error analysis" section is meant to include a mistyped command to demonstrate AIS’s error analysis.
- PR #1 changed `mkdirr` to `mkdir`.

Changes
- Reintroduce `mkdirr` in README.md and README.en.md in the “Test automatic error analysis” examples.

